### PR TITLE
Update for compliancy with Frictionless Data validator

### DIFF
--- a/R/datapackage_init.R
+++ b/R/datapackage_init.R
@@ -10,7 +10,7 @@
 #' Protocol (see \url{http://dataprotocols.org/data-packages/}). Must include
 #' the \code{name}, \code{license}, and \code{version} fields.
 #' If \code{resources} is not specified then this will be automatically
-#' generated.\code{dpmr} uses \code{jsonlite} to convert the list into a
+#' generated. \code{dpmr} uses \code{jsonlite} to convert the list into a
 #' JSON file. See the \code{\link{toJSON}} documentation for details.
 #' If \code{meta = NULL} then a barebones \code{datapackage.json} file will be
 #' created.
@@ -102,8 +102,8 @@ datapackage_init <- function(df,
                     '  ', getwd(), '/', name, '/', 'datapackage.json\n\n',
                     '  For more information see: http://dataprotocols.org/data-packages/\n'))
         meta_template(df = df, name = name, data_paths = data_base_paths) %>%
-        toJSON(pretty = T) %>%
-        writeLines(con = paste0(name, '/datapackage.json'))
+            toJSON(pretty = T,auto_unbox=T) %>%  
+            writeLines(con = paste0(name, '/datapackage.json'))
     }
     else if (!is.null(meta)){
         if (class(meta) != 'list') stop('meta must be a list', call. = F)
@@ -112,13 +112,13 @@ datapackage_init <- function(df,
             message('Adding resources to metadata saved in datapackage.json.\n')
             list(meta, resources_create(data_paths = data_base_paths,
                                         df = df)) %>%
-                toJSON(pretty = T) %>%
+                toJSON(pretty = T,auto_unbox=T) %>%
                 writeLines(con = paste0(name, '/datapackage.json'))
         }
 
         else if (!is.null(meta$resources)){
             message('Meta data saved in: datapackage.json\n')
-            meta %>% toJSON(pretty = T) %>%
+            meta %>% toJSON(pretty = T,auto_unbox=T) %>%
             writeLines(con = paste0(name, '/datapackage.json'))
         }
     }

--- a/R/datapackage_init.R
+++ b/R/datapackage_init.R
@@ -33,10 +33,10 @@
 #' Data <- data.frame(ID, A, B, C)
 #'
 #' # Initialise data package with barebones, automatically generated metadata
-#' datapackage_init(df = Data, package_name = 'My_Data_Package')
+#' datapackage_init(df = Data, package_name = 'my-data-package')
 #'
 #' # Initialise with user specified metadata
-#' meta_list <- list(name = 'My_Data_Package',
+#' meta_list <- list(name = 'my-data-package',
 #'                  title = 'A fake data package',
 #'                  last_updated = Sys.Date(),
 #'                  version = '0.1',
@@ -95,7 +95,7 @@ datapackage_init <- function(df,
     dir.create(paste0(name, '/scripts'))
 
     #----------------------- Create/validate datapackage.json ---------------- #
-    data_base_paths <- paste0('data/', name, '_data.csv')
+    data_base_paths <- paste0('data/', name, '-data.csv')
     if (is.null(meta)){ # Create bare
         message(paste0('Creating barebones metadata datapackage.json\n',
                     '- Please add additional information directly in:\n',

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,20 +13,20 @@ meta_template <- function(df, name, data_paths){
     out <- list(name = name,
         title = '',
         description = '',
-        maintainer = '',
-        contributors = '',
-        version = 1,
+        maintainer = list(),
+        contributors = list(),
+        version = "1",
         last_updated = as.Date(Sys.time()),
         homepage = '',
-        keywords = '',
-        publisher = '',
+        keywords = list(),
+        publisher = list(),
         url = '',
         base = '',
         image = '',
         license = data.frame(type = 'PDDL-1.0',
                             url = 'http://opendatacommons.org/licenses/pddl/'),
         dataDependencies = '',
-        sources = '',
+        sources = list(),
         resources = resources_create(data_paths, df = df)
     )
     return(out)
@@ -58,8 +58,8 @@ schema_df <- function(df){
 #' @noRd
 
 resources_create <- function(data_paths, df){
-    resources_out <- list(resources = data.frame(path = data_paths),
-                            schema = schema_df(df))
+    resources_out <- list(list(path = data_paths,
+                          schema =list(fields=schema_df(df))))
     return(resources_out)
 }
 


### PR DESCRIPTION
Hi Christopher,

A few corrections so the datapackage.json is compliant with OKFN data package validator. Using the dpmr CRAN version:

http://data.okfn.org/tools/validate?url=https://github.com/Yannael/my-data-package-cran

With this pull request:

http://data.okfn.org/tools/validate?url=https://github.com/Yannael/my-data-package

What I changed:
- Slightly modified how the metadata structure is built
- Added auto_unbox=T is toJSON function
- Changed name of example package so it follows the data package guidelines (http://data.okfn.org/doc/publish-faq)
